### PR TITLE
Change zip compression method, make PAR fields public

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -13,14 +13,15 @@ const CLAIMS_JWT_FILE: &str = "claims.jwt";
 /// A provider archive is a specialized ZIP file that contains a set of embedded and signed claims
 /// (a .JWT file) as well as a list of binary files, one plugin library for each supported
 /// target architecture and OS combination
+#[derive(Debug)]
 pub struct ProviderArchive {
-    libraries: HashMap<String, Vec<u8>>,
-    capid: String,
-    name: String,
-    vendor: String,
-    rev: Option<i32>,
-    ver: Option<String>,
-    claims: Option<Claims<CapabilityProvider>>,
+    pub libraries: HashMap<String, Vec<u8>>,
+    pub capid: String,
+    pub name: String,
+    pub vendor: String,
+    pub rev: Option<i32>,
+    pub ver: Option<String>,
+    pub claims: Option<Claims<CapabilityProvider>>,
 }
 
 impl ProviderArchive {
@@ -135,7 +136,7 @@ impl ProviderArchive {
         let hashes = generate_hashes(&self.libraries);
         let mut zip = zip::ZipWriter::new(destination);
         let options =
-            zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+            zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Stored);
 
         let claims = Claims::<CapabilityProvider>::new(
             self.name.to_string(),
@@ -182,7 +183,7 @@ fn generate_hashes(libraries: &HashMap<String, Vec<u8>>) -> HashMap<String, Stri
     let mut hm = HashMap::new();
     for (target, lib) in libraries.iter() {
         let hash = hash_bytes(lib);
-        hm.insert(target.to_string(), hash);
+        hm.insert(target.to_string(), hash.clone());
     }
 
     hm

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -14,13 +14,13 @@ const CLAIMS_JWT_FILE: &str = "claims.jwt";
 /// (a .JWT file) as well as a list of binary files, one plugin library for each supported
 /// target architecture and OS combination
 pub struct ProviderArchive {
-    pub libraries: HashMap<String, Vec<u8>>,
-    pub capid: String,
-    pub name: String,
-    pub vendor: String,
-    pub rev: Option<i32>,
-    pub ver: Option<String>,
-    pub claims: Option<Claims<CapabilityProvider>>,
+    libraries: HashMap<String, Vec<u8>>,
+    capid: String,
+    name: String,
+    vendor: String,
+    rev: Option<i32>,
+    ver: Option<String>,
+    claims: Option<Claims<CapabilityProvider>>,
 }
 
 impl ProviderArchive {

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -13,7 +13,6 @@ const CLAIMS_JWT_FILE: &str = "claims.jwt";
 /// A provider archive is a specialized ZIP file that contains a set of embedded and signed claims
 /// (a .JWT file) as well as a list of binary files, one plugin library for each supported
 /// target architecture and OS combination
-#[derive(Debug)]
 pub struct ProviderArchive {
     pub libraries: HashMap<String, Vec<u8>>,
     pub capid: String,
@@ -183,7 +182,7 @@ fn generate_hashes(libraries: &HashMap<String, Vec<u8>>) -> HashMap<String, Stri
     let mut hm = HashMap::new();
     for (target, lib) in libraries.iter() {
         let hash = hash_bytes(lib);
-        hm.insert(target.to_string(), hash.clone());
+        hm.insert(target.to_string(), hash);
     }
 
     hm


### PR DESCRIPTION
Due to the lossy aspect of the `Deflated` zip compression method, capability providers are modified so:
1. Their hash value changes
2. On macOS at least, the unzipped version of the provider does not function the same as the original

Because of this, I suggest changing the compression method to `Stored`, which does not compress the providers. This increases the size of the provider archive, but the `.par` can be compressed before any networking operations (e.g. registry push/pull) rather than during the build process for `.par`s.

In addition, I've added the `pub` keyword on the ProviderArchive struct so I can read those fields for [wash](https://github.com/wascc/wash).