### PR TITLE
Fixes #7, write par file only once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,5 @@ Cargo.lock
 /target
 
 # Just in case the tests fail to delete the files..
-.par
-
+*.par
+*.par.gz

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "provider-archive"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Kevin Hoffman <alothien@gmail.com>"]
 edition = "2018"
 description = "Library for reading and writing waSCC capability provider archive files"


### PR DESCRIPTION
This fixes issue #7 with the gz suffix being added to the archive even if it already exists. It also changes how the par file is written in cases where gzip compression is used. Previously, it would write the file then read that in and write the compressed file, where as now it just writes the par file once, regardless of compression.